### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/netbbsd.py
+++ b/netbbsd.py
@@ -5564,7 +5564,17 @@ class BBS:
                     if hasattr(self, 'logger'):
                         self.logger.warning(f"Remote file {filename} exceeds max size; skipped")
                     return
-                file_path = dir_path / filename
+                # Validate filename: must not contain path separators or be absolute
+                if os.path.sep in filename or (os.path.altsep and os.path.altsep in filename) or Path(filename).is_absolute():
+                    if hasattr(self, 'logger'):
+                        self.logger.warning(f"Rejected remote file with invalid filename: {filename}")
+                    return
+                file_path = (dir_path / filename).resolve()
+                # Ensure file_path is within dir_path
+                if not str(file_path).startswith(str(dir_path.resolve())):
+                    if hasattr(self, 'logger'):
+                        self.logger.warning(f"Rejected remote file with path traversal attempt: {filename}")
+                    return
                 try:
                     with open(file_path, 'wb') as fh:
                         fh.write(data_bytes)


### PR DESCRIPTION
Potential fix for [https://github.com/Thiesi/NetBBSD/security/code-scanning/1](https://github.com/Thiesi/NetBBSD/security/code-scanning/1)

To fix this vulnerability, we need to ensure that the constructed file path is contained within the intended uploads directory and does not allow directory traversal or writing outside the designated area. The best way to do this is to normalize the path using `os.path.normpath` or `Path.resolve()`, and then check that the resulting path is a child of the intended uploads directory. If the check fails, the file should not be written and an error should be logged. Additionally, we should reject absolute paths and sanitize the filename to remove any path separators.

The changes should be made in the region where `file_path` is constructed and used (lines 5567–5571). We should:
- Normalize and validate the path.
- Reject filenames containing path separators or absolute paths.
- Optionally, use a sanitization function to further clean the filename.

No new methods are strictly required, but we may want to add a helper function for filename validation if desired.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
